### PR TITLE
Do not collapse whitespace for heading tags

### DIFF
--- a/index.js
+++ b/index.js
@@ -213,12 +213,15 @@ function htmlmin (str, options) {
       }
 
       if (options.collapseWhitespace) {
+
+        var nonCollapsedWhiteSpaceElements = ['p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6']
+
         // left trim
         if (lastTag) {
           text = text.replace(/^[\n\s\t\r]+/im, '')
         }
 
-        if (lastTag !== 'p' && lastTag) {
+        if (nonCollapsedWhiteSpaceElements.indexOf(lastTag) == -1 && lastTag) {
           text = text.replace(/[\n\s\t\r]+$/im, '')
         }
 

--- a/test/allSpec.js
+++ b/test/allSpec.js
@@ -103,6 +103,9 @@ describe('htmlmin', function () {
       'u'
     ]
     list.forEach(function (el) {
+      assert.equal(htmlmin('<h2>foo <' + el + '>baz</' + el + '> bar</h2>', {
+        collapseWhitespace: true
+      }), '<h2>foo <' + el + '>baz</' + el + '> bar</h2>')
       assert.equal(htmlmin('<p>foo <' + el + '>baz</' + el + '> bar</p>', {
         collapseWhitespace: true
       }), '<p>foo <' + el + '>baz</' + el + '> bar</p>')


### PR DESCRIPTION
fixes an issue where `<h2>hello <span>my</span> friend</h2>` would be compiled into `<h2>hello<span>my</span> friend</h2>` where it shouldn't.

Previously it only worked for the `p` tag
